### PR TITLE
Fixing error with goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,6 +21,11 @@ builds:
       - windows
       - darwin
 
+    ldflags:
+      # - -s -w -X cmd.version={{.Version}} -X cmd.commit={{.Commit}} -X cmd.date={{.Date}} -X cmd.builtBy=goreleaser
+      - -s -w -X 'github.com/romaingallez/clim_cli/cmd.Version={{.Version}}' -X 'github.com/romaingallez/clim_cli/cmd.Commit={{.Commit}}' -X 'github.com/romaingallez/clim_cli/cmd.Date={{.Date}}' -X 'github.com/romaingallez/clim_cli/cmd.BuiltBy=goreleaser'
+      - -extldflags "-static"
+
 archives:
   - format: tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -10,9 +10,10 @@ import (
 )
 
 var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
+	Version = "dev"
+	Commit  = "none"
+	Date    = "unknown"
+	BuiltBy = "unknown"
 )
 
 // versionCmd represents the version command
@@ -26,7 +27,7 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("clim_cli %s, commit %s, built at %s", version, commit, date)
+		fmt.Printf("clim_cli %s, commit %s, built at %s, build by %s\n", Version, Commit, Date, BuiltBy)
 	},
 }
 


### PR DESCRIPTION
Adding correct parameters so that ldflags are set correctly and can be accessed by the version command